### PR TITLE
replace deprecated eregi with stripos

### DIFF
--- a/vulnerabilities/csrf/source/medium.php
+++ b/vulnerabilities/csrf/source/medium.php
@@ -2,7 +2,7 @@
 
 if( isset( $_GET[ 'Change' ] ) ) {
 	// Checks to see where the request came from
-	if( eregi( $_SERVER[ 'SERVER_NAME' ], $_SERVER[ 'HTTP_REFERER' ] ) ) {
+	if( stripos( $_SERVER[ 'HTTP_REFERER' ] ,$_SERVER[ 'SERVER_NAME' ])!=-1 ) {
 		// Get input
 		$pass_new  = $_GET[ 'password_new' ];
 		$pass_conf = $_GET[ 'password_conf' ];


### PR DESCRIPTION
Eregi was deprecated in PHP 5.3.0 and completely removed in PHP 7.0.0. I replaced it with stripos.