### PR TITLE
Remove form action from DOM xss lab

### DIFF
--- a/vulnerabilities/xss_d/index.php
+++ b/vulnerabilities/xss_d/index.php
@@ -45,7 +45,7 @@ $page[ 'body' ] = <<<EOF
  
  		<p>Please choose a language:</p>
 
-		<form name="XSS" action="/vulnerabilities/xss_d/" method="GET">
+		<form name="XSS" method="GET">
 			<select name="default">
 				<script>
 					if (document.location.href.indexOf("default=") >= 0) {

--- a/vulnerabilities/xss_d/source/high.php
+++ b/vulnerabilities/xss_d/source/high.php
@@ -12,7 +12,7 @@ if ( array_key_exists( "default", $_GET ) && !is_null ($_GET[ 'default' ]) ) {
 			# ok
 			break;
 		default:
-			header ("location: /vulnerabilities/xss_d/?default=English");
+			header ("location: ?default=English");
 			exit;
 	}
 }

--- a/vulnerabilities/xss_d/source/medium.php
+++ b/vulnerabilities/xss_d/source/medium.php
@@ -6,7 +6,7 @@ if ( array_key_exists( "default", $_GET ) && !is_null ($_GET[ 'default' ]) ) {
 	
 	# Do not allow script tags
 	if (stripos ($default, "<script") !== false) {
-		header ("location: /vulnerabilities/xss_d/?default=English");
+		header ("location: ?default=English");
 		exit;
 	}
 }


### PR DESCRIPTION
Form action seems to have been set with the assumption DVWA was installed in the root of web server, not in a "dvwa" folder as I would assume is the default for most installs. The action can be removed entirely and the default is correct, removing the maintenance headache.