### PR TITLE
Use "!==" operator for stripos() function

### DIFF
--- a/vulnerabilities/csrf/source/medium.php
+++ b/vulnerabilities/csrf/source/medium.php
@@ -2,7 +2,7 @@
 
 if( isset( $_GET[ 'Change' ] ) ) {
 	// Checks to see where the request came from
-	if( stripos( $_SERVER[ 'HTTP_REFERER' ] ,$_SERVER[ 'SERVER_NAME' ])!=-1 ) {
+	if( stripos( $_SERVER[ 'HTTP_REFERER' ] ,$_SERVER[ 'SERVER_NAME' ]) !== false ) {
 		// Get input
 		$pass_new  = $_GET[ 'password_new' ];
 		$pass_conf = $_GET[ 'password_conf' ];


### PR DESCRIPTION
The operator to test the return value of the [`stripos()`](https://secure.php.net/manual/en/function.stripos.php#refsect1-function.stripos-returnvalues) function must be `!==` (like in the [vulnerabilities/xss_d/source/medium.php](https://github.com/ethicalhack3r/DVWA/blob/master/vulnerabilities/xss_d/source/medium.php) code). Currently, all requests are allowed regardless of the contents of the Referer header.

This fixes #131 bug.