### PR TITLE
Add .bak file copy operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config/config.inc.php
+Dockerfile

--- a/dvwa/includes/DBMS/MySQL.php
+++ b/dvwa/includes/DBMS/MySQL.php
@@ -6,6 +6,8 @@ This file contains all of the code to setup the initial MySQL database. (setup.p
 
 */
 
+define( 'DVWA_WEB_PAGE_TO_ROOT', '../../../' );
+
 if( !@($GLOBALS["___mysqli_ston"] = mysqli_connect( $_DVWA[ 'db_server' ],  $_DVWA[ 'db_user' ],  $_DVWA[ 'db_password' ] )) ) {
 	dvwaMessagePush( "Could not connect to the MySQL service.<br />Please check the config file." );
 	dvwaPageReload();
@@ -80,6 +82,16 @@ dvwaMessagePush( "Data inserted into 'guestbook' table." );
 
 // Done
 dvwaMessagePush( "<em>Setup successful</em>!" );
+
+// Copy .bak for a fun directory listing vuln
+$conf = DVWA_WEB_PAGE_TO_ROOT . 'config/config.inc.php';
+$bakconf = DVWA_WEB_PAGE_TO_ROOT . 'config/config.inc.php.bak';
+if (file_exists($conf)) {
+	// Who cares if it fails. Suppress.
+	@copy($conf, $bakconf);
+}
+
+
 if( !dvwaIsLoggedIn())
 	dvwaMessagePush( "Please <a href='login.php'>login</a>.<script>setTimeout(function(){window.location.href='login.php'},5000);</script>" );
 dvwaPageReload();

--- a/dvwa/includes/DBMS/MySQL.php
+++ b/dvwa/includes/DBMS/MySQL.php
@@ -80,8 +80,7 @@ if( !mysqli_query($GLOBALS["___mysqli_ston"],  $insert ) ) {
 dvwaMessagePush( "Data inserted into 'guestbook' table." );
 
 
-// Done
-dvwaMessagePush( "<em>Setup successful</em>!" );
+
 
 // Copy .bak for a fun directory listing vuln
 $conf = DVWA_WEB_PAGE_TO_ROOT . 'config/config.inc.php';
@@ -91,6 +90,10 @@ if (file_exists($conf)) {
 	@copy($conf, $bakconf);
 }
 
+dvwaMessagePush( "Backup file /config/config.inc.php.bak automatically created" );
+
+// Done
+dvwaMessagePush( "<em>Setup successful</em>!" );
 
 if( !dvwaIsLoggedIn())
 	dvwaMessagePush( "Please <a href='login.php'>login</a>.<script>setTimeout(function(){window.location.href='login.php'},5000);</script>" );

--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -548,6 +548,8 @@ function tokenField() {  # Return a field for the (CSRF) token
 // Setup Functions --
 $PHPUploadPath    = realpath( getcwd() . DIRECTORY_SEPARATOR . DVWA_WEB_PAGE_TO_ROOT . "hackable" . DIRECTORY_SEPARATOR . "uploads" ) . DIRECTORY_SEPARATOR;
 $PHPIDSPath       = realpath( getcwd() . DIRECTORY_SEPARATOR . DVWA_WEB_PAGE_TO_ROOT . "external" . DIRECTORY_SEPARATOR . "phpids" . DIRECTORY_SEPARATOR . dvwaPhpIdsVersionGet() . DIRECTORY_SEPARATOR . "lib" . DIRECTORY_SEPARATOR . "IDS" . DIRECTORY_SEPARATOR . "tmp" . DIRECTORY_SEPARATOR . "phpids_log.txt" );
+$PHPCONFIGPath       = realpath( getcwd() . DIRECTORY_SEPARATOR . DVWA_WEB_PAGE_TO_ROOT . "config");
+
 
 $phpDisplayErrors = 'PHP function display_errors: <em>' . ( ini_get( 'display_errors' ) ? 'Enabled</em> <i>(Easy Mode!)</i>' : 'Disabled</em>' );                                                  // Verbose error messages (e.g. full path disclosure)
 $phpSafeMode      = 'PHP function safe_mode: <span class="' . ( ini_get( 'safe_mode' ) ? 'failure">Enabled' : 'success">Disabled' ) . '</span>';                                                   // DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0
@@ -557,10 +559,10 @@ $phpURLFopen      = 'PHP function allow_url_fopen: <span class="' . ( ini_get( '
 $phpGD            = 'PHP module gd: <span class="' . ( ( extension_loaded( 'gd' ) && function_exists( 'gd_info' ) ) ? 'success">Installed' : 'failure">Missing' ) . '</span>';                    // File Upload
 $phpMySQL         = 'PHP module mysql: <span class="' . ( ( extension_loaded( 'mysqli' ) && function_exists( 'mysqli_query' ) ) ? 'success">Installed' : 'failure">Missing' ) . '</span>';                // Core DVWA
 $phpPDO           = 'PHP module pdo_mysql: <span class="' . ( extension_loaded( 'pdo_mysql' ) ? 'success">Installed' : 'failure">Missing' ) . '</span>';                // SQLi
-
 $DVWARecaptcha    = 'reCAPTCHA key: <span class="' . ( ( isset( $_DVWA[ 'recaptcha_public_key' ] ) && $_DVWA[ 'recaptcha_public_key' ] != '' ) ? 'success">' . $_DVWA[ 'recaptcha_public_key' ] : 'failure">Missing' ) . '</span>';
 
 $DVWAUploadsWrite = '[User: ' . get_current_user() . '] Writable folder ' . $PHPUploadPath . ': <span class="' . ( is_writable( $PHPUploadPath ) ? 'success">Yes' : 'failure">No' ) . '</span>';                                     // File Upload
+$bakWritable = '[User: ' . get_current_user() . '] Writable folder ' . $PHPCONFIGPath . ': <span class="' . ( is_writable( $PHPCONFIGPath ) ? 'success">Yes' : 'failure">No' ) . '</span>';   // config.php.bak check                                  // File Upload
 $DVWAPHPWrite     = '[User: ' . get_current_user() . '] Writable file ' . $PHPIDSPath . ': <span class="' . ( is_writable( $PHPIDSPath ) ? 'success">Yes' : 'failure">No' ) . '</span>';                                              // PHPIDS
 
 $DVWAOS           = 'Operating system: <em>' . ( strtoupper( substr (PHP_OS, 0, 3)) === 'WIN' ? 'Windows' : '*nix' ) . '</em>';

--- a/setup.php
+++ b/setup.php
@@ -69,6 +69,9 @@ $page[ 'body' ] .= "
 	{$DVWAUploadsWrite}<br />
 	{$DVWAPHPWrite}<br />
 	<br />
+	<br />
+	{$bakWritable}
+	<br />
 	<i><span class=\"failure\">Status in red</span>, indicate there will be an issue when trying to complete some modules.</i><br />
 	<br /><br /><br />
 


### PR DESCRIPTION
Addresses issue #59, which creates a backup file. After it successfully sets up it copies over a backup file. While this might be useful in troubleshooting, it's mainly so someone with indexing on can scan and visit /config and download the .bak file for the creds goodies.

Tested in an Ubuntu 16.04 t2.micro AWS instance in both /var/www/html (document root) and in a /var/www/html/test (folder in a document root) without issue. Intentionally suppresses copy operation.