### PR TITLE
turned off XSS protection in HTTP headers

### DIFF
--- a/vulnerabilities/xss_r/source/high.php
+++ b/vulnerabilities/xss_r/source/high.php
@@ -1,5 +1,7 @@
 <?php
 
+header ("X-XSS-Protection: 0");
+
 // Is there any input?
 if( array_key_exists( "name", $_GET ) && $_GET[ 'name' ] != NULL ) {
 	// Get input

--- a/vulnerabilities/xss_r/source/low.php
+++ b/vulnerabilities/xss_r/source/low.php
@@ -1,5 +1,7 @@
 <?php
 
+header ("X-XSS-Protection: 0");
+
 // Is there any input?
 if( array_key_exists( "name", $_GET ) && $_GET[ 'name' ] != NULL ) {
 	// Feedback for end user

--- a/vulnerabilities/xss_r/source/medium.php
+++ b/vulnerabilities/xss_r/source/medium.php
@@ -1,5 +1,7 @@
 <?php
 
+header ("X-XSS-Protection: 0");
+
 // Is there any input?
 if( array_key_exists( "name", $_GET ) && $_GET[ 'name' ] != NULL ) {
 	// Get input


### PR DESCRIPTION
Setting the "X-XSS-Protection: 0" header in reflected XSS low, medium and high so that Chrome doesn't block the attacks. Leaving it out of impossible as Chrome blocking is one of the things to help make it impossible.

Based on a discussion in #188