### PR TITLE
Changing onClick to onclick

### DIFF
--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -425,13 +425,13 @@ function dvwaExternalLinkUrlGet( $pLink,$text=null ) {
 
 function dvwaButtonHelpHtmlGet( $pId ) {
 	$security = dvwaSecurityLevelGet();
-	return "<input type=\"button\" value=\"View Help\" class=\"popup_button\" onClick=\"javascript:popUp( '" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_help.php?id={$pId}&security={$security}' )\">";
+	return "<input type=\"button\" value=\"View Help\" class=\"popup_button\" onclick=\"javascript:popUp( '" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_help.php?id={$pId}&security={$security}' )\">";
 }
 
 
 function dvwaButtonSourceHtmlGet( $pId ) {
 	$security = dvwaSecurityLevelGet();
-	return "<input type=\"button\" value=\"View Source\" class=\"popup_button\" onClick=\"javascript:popUp( '" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_source.php?id={$pId}&security={$security}' )\">";
+	return "<input type=\"button\" value=\"View Source\" class=\"popup_button\" onclick=\"javascript:popUp( '" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_source.php?id={$pId}&security={$security}' )\">";
 }
 
 

--- a/vulnerabilities/sqli/index.php
+++ b/vulnerabilities/sqli/index.php
@@ -51,7 +51,7 @@ $page[ 'body' ] .= "
 
 	<div class=\"vulnerable_code_area\">";
 if( $vulnerabilityFile == 'high.php' ) {
-	$page[ 'body' ] .= "Click <a href=\"#\" onClick=\"javascript:popUp('session-input.php');return false;\">here to change your ID</a>.";
+	$page[ 'body' ] .= "Click <a href=\"#\" onclick=\"javascript:popUp('session-input.php');return false;\">here to change your ID</a>.";
 }
 else {
 	$page[ 'body' ] .= "

--- a/vulnerabilities/sqli_blind/index.php
+++ b/vulnerabilities/sqli_blind/index.php
@@ -51,7 +51,7 @@ $page[ 'body' ] .= "
 
 	<div class=\"vulnerable_code_area\">";
 if( $vulnerabilityFile == 'high.php' ) {
-	$page[ 'body' ] .= "Click <a href=\"#\" onClick=\"javascript:popUp('cookie-input.php');return false;\">here to change your ID</a>.";
+	$page[ 'body' ] .= "Click <a href=\"#\" onclick=\"javascript:popUp('cookie-input.php');return false;\">here to change your ID</a>.";
 }
 else {
 	$page[ 'body' ] .= "

--- a/vulnerabilities/view_source_all.php
+++ b/vulnerabilities/view_source_all.php
@@ -99,7 +99,7 @@ $page[ 'body' ] .= "
 	<br /> <br />
 
 	<form>
-		<input type=\"button\" value=\"<-- Back\" onClick=\"history.go(-1);return true;\">
+		<input type=\"button\" value=\"<-- Back\" onclick=\"history.go(-1);return true;\">
 	</form>
 
 </div>\n";

--- a/vulnerabilities/xss_s/index.php
+++ b/vulnerabilities/xss_s/index.php
@@ -48,7 +48,10 @@ $page[ 'body' ] .= "
 				</tr>
 				<tr>
 					<td width=\"100\">&nbsp;</td>
-					<td><input name=\"btnSign\" type=\"submit\" value=\"Sign Guestbook\" onClick=\"return checkForm();\"></td>
+					<td>
+						<input name=\"btnSign\" type=\"submit\" value=\"Sign Guestbook\" onClick=\"return checkForm();\" />
+						<input name=\"btnSign\" type=\"submit\" value=\"Clear Guestbook\" onClick=\"return confirmClear();\" />
+					</td>
 				</tr>
 			</table>\n";
 

--- a/vulnerabilities/xss_s/index.php
+++ b/vulnerabilities/xss_s/index.php
@@ -36,7 +36,7 @@ $page[ 'body' ] .= "
 	<h1>Vulnerability: Stored Cross Site Scripting (XSS)</h1>
 
 	<div class=\"vulnerable_code_area\">
-		<form method=\"post\" name=\"guestform\" onsubmit=\"return validate_form(this)\">
+		<form method=\"post\" name=\"guestform\" \">
 			<table width=\"550\" border=\"0\" cellpadding=\"2\" cellspacing=\"1\">
 				<tr>
 					<td width=\"100\">Name *</td>
@@ -49,8 +49,8 @@ $page[ 'body' ] .= "
 				<tr>
 					<td width=\"100\">&nbsp;</td>
 					<td>
-						<input name=\"btnSign\" type=\"submit\" value=\"Sign Guestbook\" onClick=\"return checkForm();\" />
-						<input name=\"btnSign\" type=\"submit\" value=\"Clear Guestbook\" onClick=\"return confirmClear();\" />
+						<input name=\"btnSign\" type=\"submit\" value=\"Sign Guestbook\" onclick=\"return validate_form(this.form);\" />
+						<!--<input name=\"btnSign\" type=\"submit\" value=\"Clear Guestbook\" onClick=\"return confirmClear();\" /> -->
 					</td>
 				</tr>
 			</table>\n";


### PR DESCRIPTION
I've just been trying to debug something and noticed there are a handful of uses of the onClick event. As this should be onclick (lower c), the event should never be fired but oddly in all cases except the one that I was looking at, Firefox silently converts the onClick to onclick and then it works.

This will ensure all browsers handle the clicks correctly.

(Ignore the clear guestbook references, that will be the next PR)
