### PR TITLE
Fix avatar image links for server on non-standard port

### DIFF
--- a/dvwa/includes/DBMS/MySQL.php
+++ b/dvwa/includes/DBMS/MySQL.php
@@ -48,7 +48,7 @@ dvwaMessagePush( "'users' table was created." );
 
 // Insert some data into users
 // Get the base directory for the avatar media...
-$baseUrl  = 'http://' . $_SERVER[ 'SERVER_NAME' ] . $_SERVER[ 'PHP_SELF' ];
+$baseUrl  = 'http://' . $_SERVER[ 'HTTP_HOST' ] . $_SERVER[ 'PHP_SELF' ];
 $stripPos = strpos( $baseUrl, 'setup.php' );
 $baseUrl  = substr( $baseUrl, 0, $stripPos ) . 'hackable/users/';
 


### PR DESCRIPTION
DVWA is recommended to run in a VM. Accessing VM ports often
involves port forwarding, which may mean that the browser running
on the host will
access non-standard port. In this case, avatar images are not
showing. That is because PHP variable `$_SERVER['SERVER_NAME']`
does not contain the port.

Use `$_SERVER['HTTP_HOST']` instead. This might give additional
bonus in form of new vulnerabilities, as this variable is read
from the client's request.

Closes #218.