### PR TITLE
fixing avatar image URLs

### DIFF
--- a/dvwa/includes/DBMS/MySQL.php
+++ b/dvwa/includes/DBMS/MySQL.php
@@ -47,17 +47,14 @@ dvwaMessagePush( "'users' table was created." );
 
 
 // Insert some data into users
-// Get the base directory for the avatar media...
-$baseUrl  = 'http://' . $_SERVER[ 'SERVER_NAME' ] . $_SERVER[ 'PHP_SELF' ];
-$stripPos = strpos( $baseUrl, 'setup.php' );
-$baseUrl  = substr( $baseUrl, 0, $stripPos ) . 'hackable/users/';
+$avatarUrl  = '/hackable/users/';
 
 $insert = "INSERT INTO users VALUES
-	('1','admin','admin','admin',MD5('password'),'{$baseUrl}admin.jpg', NOW(), '0'),
-	('2','Gordon','Brown','gordonb',MD5('abc123'),'{$baseUrl}gordonb.jpg', NOW(), '0'),
-	('3','Hack','Me','1337',MD5('charley'),'{$baseUrl}1337.jpg', NOW(), '0'),
-	('4','Pablo','Picasso','pablo',MD5('letmein'),'{$baseUrl}pablo.jpg', NOW(), '0'),
-	('5','Bob','Smith','smithy',MD5('password'),'{$baseUrl}smithy.jpg', NOW(), '0');";
+	('1','admin','admin','admin',MD5('password'),'{$avatarUrl}admin.jpg', NOW(), '0'),
+	('2','Gordon','Brown','gordonb',MD5('abc123'),'{$avatarUrl}gordonb.jpg', NOW(), '0'),
+	('3','Hack','Me','1337',MD5('charley'),'{$avatarUrl}1337.jpg', NOW(), '0'),
+	('4','Pablo','Picasso','pablo',MD5('letmein'),'{$avatarUrl}pablo.jpg', NOW(), '0'),
+	('5','Bob','Smith','smithy',MD5('password'),'{$avatarUrl}smithy.jpg', NOW(), '0');";
 if( !mysqli_query($GLOBALS["___mysqli_ston"],  $insert ) ) {
 	dvwaMessagePush( "Data could not be inserted into 'users' table<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
 	dvwaPageReload();


### PR DESCRIPTION
Replacing this really old PR https://github.com/ethicalhack3r/DVWA/pull/219/commits/daf1f039d3677b38ad42a005c9a29bc0cf0fc47b with a simpler version that just uses relative URLs.

The `$stripPos` and `$baseUrl` variables that I've removed are only mentioned in the Postgresql library so won't affect anything:

```
$ find . -type f -exec grep -H "\$stripPos" '{}' \;
./dvwa/includes/DBMS/PGSQL.php:$stripPos = strpos( $baseUrl, 'dvwa/setup.php' );
./dvwa/includes/DBMS/PGSQL.php:$baseUrl = substr( $baseUrl, 0, $stripPos ).'dvwa/hackable/users/';

$ find . -type f -exec grep -H "\$baseUrl" '{}' \;
./dvwa/includes/DBMS/PGSQL.php:$baseUrl = 'http://'.$_SERVER[ 'SERVER_NAME' ].$_SERVER[ 'PHP_SELF' ];
./dvwa/includes/DBMS/PGSQL.php:$stripPos = strpos( $baseUrl, 'dvwa/setup.php' );
./dvwa/includes/DBMS/PGSQL.php:$baseUrl = substr( $baseUrl, 0, $stripPos ).'dvwa/hackable/users/';
./dvwa/includes/DBMS/PGSQL.php: ('1','admin','admin','admin',MD5('password'),'{$baseUrl}admin.jpg'),
./dvwa/includes/DBMS/PGSQL.php: ('2','Gordon','Brown','gordonb',MD5('abc123'),'{$baseUrl}gordonb.jpg'),
./dvwa/includes/DBMS/PGSQL.php: ('3','Hack','Me','1337',MD5('charley'),'{$baseUrl}1337.jpg'),
./dvwa/includes/DBMS/PGSQL.php: ('4','Pablo','Picasso','pablo',MD5('letmein'),'{$baseUrl}pablo.jpg'),
./dvwa/includes/DBMS/PGSQL.php: ('5','bob','smith','smithy',MD5('password'),'{$baseUrl}smithy.jpg');";
```

