### PR TITLE
Edit CAPTCHA URL

### DIFF
--- a/vulnerabilities/brute/help/help.php
+++ b/vulnerabilities/brute/help/help.php
@@ -44,7 +44,7 @@
 			This level also extends on the medium level, by waiting when there is a failed login but this time it is a random amount of time between two and four seconds.
 			The idea of this is to try and confuse any timing predictions.</p>
 
-		<p>Using a <?php echo dvwaExternalLinkUrlGet( 'http://www.captcha.net/', 'CAPTCHA' ); ?> form could have a similar effect as a CSRF token.</p>
+		<p>Using a <?php echo dvwaExternalLinkUrlGet( 'https://en.wikipedia.org/wiki/CAPTCHA', 'CAPTCHA' ); ?> form could have a similar effect as a CSRF token.</p>
 
 		<br />
 

--- a/vulnerabilities/captcha/help/help.php
+++ b/vulnerabilities/captcha/help/help.php
@@ -6,7 +6,7 @@
 	<tr>
 	<td><div id="code">
 		<h3>About</h3>
-		<p>A <?php echo dvwaExternalLinkUrlGet( 'http://www.captcha.net/', 'CAPTCHA' ); ?> is a program that can tell whether its user is a human or a computer. You've probably seen
+		<p>A <?php echo dvwaExternalLinkUrlGet( 'https://en.wikipedia.org/wiki/CAPTCHA', 'CAPTCHA' ); ?> is a program that can tell whether its user is a human or a computer. You've probably seen
 			them - colourful images with distorted text at the bottom of Web registration forms. CAPTCHAs are used by many websites to prevent abuse from
 			"bots", or automated programs usually written to generate spam. No computer program can read distorted text as well as humans can, so bots
 			cannot navigate sites protected by CAPTCHAs.</p>
@@ -58,5 +58,5 @@
 
 	<br />
 
-	<p>Reference: <?php echo dvwaExternalLinkUrlGet( 'http://www.captcha.net/' ); ?></p>
+	<p>Reference: <?php echo dvwaExternalLinkUrlGet( 'https://en.wikipedia.org/wiki/CAPTCHA' ); ?></p>
 </div>

--- a/vulnerabilities/captcha/index.php
+++ b/vulnerabilities/captcha/index.php
@@ -87,7 +87,7 @@ $page[ 'body' ] .= "
 
 	<h2>More Information</h2>
 	<ul>
-		<li>" . dvwaExternalLinkUrlGet( 'http://www.captcha.net/' ) . "</li>
+		<li>" . dvwaExternalLinkUrlGet( 'https://en.wikipedia.org/wiki/CAPTCHA' ) . "</li>
 		<li>" . dvwaExternalLinkUrlGet( 'https://www.google.com/recaptcha/' ) . "</li>
 		<li>" . dvwaExternalLinkUrlGet( 'https://www.owasp.org/index.php/Testing_for_Captcha_(OWASP-AT-012)' ) . "</li>
 	</ul>


### PR DESCRIPTION
"http://www.captcha.net/" website no longer exists so I've changed it to [Wikipedia CAPTCHA page](https://en.wikipedia.org/wiki/CAPTCHA).