### PR TITLE
moved from onclick to adding event handlers

### DIFF
--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -328,6 +328,7 @@ function dvwaHtmlEcho( $pPage ) {
 			<div id=\"footer\">
 
 				<p>Damn Vulnerable Web Application (DVWA) v" . dvwaVersionGet() . "</p>
+				<script src='/dvwa/js/add_event_listeners.js'></script>
 
 			</div>
 
@@ -425,13 +426,13 @@ function dvwaExternalLinkUrlGet( $pLink,$text=null ) {
 
 function dvwaButtonHelpHtmlGet( $pId ) {
 	$security = dvwaSecurityLevelGet();
-	return "<input type=\"button\" value=\"View Help\" class=\"popup_button\" onclick=\"javascript:popUp( '" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_help.php?id={$pId}&security={$security}' )\">";
+	return "<input type=\"button\" value=\"View Help\" class=\"popup_button\" id='help_button' data-help-url='" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_help.php?id={$pId}&security={$security}' )\">";
 }
 
 
 function dvwaButtonSourceHtmlGet( $pId ) {
 	$security = dvwaSecurityLevelGet();
-	return "<input type=\"button\" value=\"View Source\" class=\"popup_button\" onclick=\"javascript:popUp( '" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_source.php?id={$pId}&security={$security}' )\">";
+	return "<input type=\"button\" value=\"View Source\" class=\"popup_button\" id='source_button' data-source-url='" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_source.php?id={$pId}&security={$security}' )\">";
 }
 
 

--- a/dvwa/js/add_event_listeners.js
+++ b/dvwa/js/add_event_listeners.js
@@ -1,0 +1,24 @@
+// These functions need to be called after the content they reference
+// has been added to the page otherwise they will fail.
+
+function addEventListeners() {
+	var source_button = document.getElementById ("source_button");
+
+	if (source_button) {
+		source_button.addEventListener("click", function() {
+			var url=source_button.dataset.sourceUrl;
+			popUp (url);
+		});
+	}
+
+	var help_button = document.getElementById ("help_button");
+
+	if (help_button) {
+		help_button.addEventListener("click", function() {
+			var url=help_button.dataset.helpUrl;
+			popUp (url);
+		});
+	}
+}
+
+addEventListeners();

--- a/dvwa/js/dvwaPage.js
+++ b/dvwa/js/dvwaPage.js
@@ -3,7 +3,7 @@
 function popUp(URL) {
 	day = new Date();
 	id = day.getTime();
-	eval("page" + id + " = window.open(URL, '" + id + "', 'toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=500,height=300,left = 540,top = 250');");
+	eval("page" + id + " = window.open(URL, '" + id + "', 'toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=800,height=300,left=540,top=250');");
 }
 
 /* Form validation */


### PR DESCRIPTION
So that my CSP modules will work without killing the help and source buttons I've removed their onclick and added a JS file that adds an event listener. This removes inline JS so I can block it with CSP and not break things.

I've tested in Firefox and Chrome and it works fine, could do with testing in other browsers just to be sure.

I also increased the default width of the help window to fit the text so you don't have to scroll left/right to read it all.