### PR TITLE
Avatar does not show on brute force

### DIFF
--- a/vulnerabilities/brute/source/low.php
+++ b/vulnerabilities/brute/source/low.php
@@ -19,7 +19,7 @@ if( isset( $_GET[ 'Login' ] ) ) {
 
 		// Login successful
 		$html .= "<p>Welcome to the password protected area {$user}</p>";
-		$html .= "<img src=\"{$avatar}\" />";
+		$html .= "<img src=\"../../{$avatar}\" />";
 	}
 	else {
 		// Login failed


### PR DESCRIPTION
If username and password are correct, avatar does not show because false path to avatar image. This also applies to medium, high & impossible file.