### PR TITLE
Insert missing equal signs ("=") in example php.ini

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -1,5 +1,5 @@
 ; This file attempts to overwrite the original php.ini file. Doesnt always work.
 
 magic_quotes_gpc = Off
-allow_url_fopen on
-allow_url_include on
+allow_url_fopen = on
+allow_url_include = on


### PR DESCRIPTION
When setting up an DVWA instance I noticed the syntax error, thus I suggest this minor fix.

Cheers,
lauritzh