### PR TITLE
correctly reference JS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+# Neither the config file or its backup should go
+# into the repo.
+config/config.inc.php.bak
 config/config.inc.php
+
 Dockerfile
 
 # Vim swap files

--- a/vulnerabilities/javascript/source/high.php
+++ b/vulnerabilities/javascript/source/high.php
@@ -1,5 +1,3 @@
 <?php
-$page[ 'body' ] .= <<<EOF
-<script src="/vulnerabilities/javascript/source/high.js"></script>
-EOF;
+$page[ 'body' ] .= '<script src="' . DVWA_WEB_PAGE_TO_ROOT . 'vulnerabilities/javascript/source/high.js"></script>';
 ?>

--- a/vulnerabilities/javascript/source/medium.php
+++ b/vulnerabilities/javascript/source/medium.php
@@ -1,5 +1,3 @@
 <?php
-$page[ 'body' ] .= <<<EOF
-<script src="/vulnerabilities/javascript/source/medium.js"></script>
-EOF;
+$page[ 'body' ] .= '<script src="' . DVWA_WEB_PAGE_TO_ROOT . 'vulnerabilities/javascript/source/medium.js"></script>';
 ?>


### PR DESCRIPTION
When I wrote the module I assumed the files were located off the root, the fix in #340 assumes they are off /dvwa. This fixes it correctly and makes the path relative.