### PR TITLE
Displaying mysql connection error details

### DIFF
--- a/dvwa/includes/DBMS/MySQL.php
+++ b/dvwa/includes/DBMS/MySQL.php
@@ -11,7 +11,7 @@ if( !defined( 'DVWA_WEB_PAGE_TO_ROOT' ) ) {
 }
 
 if( !@($GLOBALS["___mysqli_ston"] = mysqli_connect( $_DVWA[ 'db_server' ],  $_DVWA[ 'db_user' ],  $_DVWA[ 'db_password' ] )) ) {
-	dvwaMessagePush( "Could not connect to the MySQL service.<br />Please check the config file." );
+	dvwaMessagePush( "Could not connect to the MySQL service.<br />Please check the config file.<br />" . mysqli_connect_errno() . ": " . mysqli_connect_error() . "." );
 	if ($_DVWA[ 'db_user' ] == "root") {
 		dvwaMessagePush( 'Your database user is root, if you are using MariaDB, this will not work, please read the README.md file.' );
 	}

--- a/dvwa/includes/DBMS/MySQL.php
+++ b/dvwa/includes/DBMS/MySQL.php
@@ -11,7 +11,7 @@ if( !defined( 'DVWA_WEB_PAGE_TO_ROOT' ) ) {
 }
 
 if( !@($GLOBALS["___mysqli_ston"] = mysqli_connect( $_DVWA[ 'db_server' ],  $_DVWA[ 'db_user' ],  $_DVWA[ 'db_password' ] )) ) {
-	dvwaMessagePush( "Could not connect to the MySQL service.<br />Please check the config file.<br />" . mysqli_connect_errno() . ": " . mysqli_connect_error() . "." );
+	dvwaMessagePush( "Could not connect to the MySQL service.<br />Please check the config file.<br />MySQL Error #" . mysqli_connect_errno() . ": " . mysqli_connect_error() . "." );
 	if ($_DVWA[ 'db_user' ] == "root") {
 		dvwaMessagePush( 'Your database user is root, if you are using MariaDB, this will not work, please read the README.md file.' );
 	}

--- a/dvwa/includes/DBMS/MySQL.php
+++ b/dvwa/includes/DBMS/MySQL.php
@@ -11,7 +11,7 @@ if( !defined( 'DVWA_WEB_PAGE_TO_ROOT' ) ) {
 }
 
 if( !@($GLOBALS["___mysqli_ston"] = mysqli_connect( $_DVWA[ 'db_server' ],  $_DVWA[ 'db_user' ],  $_DVWA[ 'db_password' ] )) ) {
-	dvwaMessagePush( "Could not connect to the MySQL service.<br />Please check the config file.<br />MySQL Error #" . mysqli_connect_errno() . ": " . mysqli_connect_error() . "." );
+	dvwaMessagePush( "Could not connect to the database service.<br />Please check the config file.<br />Database Error #" . mysqli_connect_errno() . ": " . mysqli_connect_error() . "." );
 	if ($_DVWA[ 'db_user' ] == "root") {
 		dvwaMessagePush( 'Your database user is root, if you are using MariaDB, this will not work, please read the README.md file.' );
 	}


### PR DESCRIPTION
For newer versions of MySQL, there is charset error and caching_sha2_password issue. The existing message shown is not indicative. So I am displaying the error no and error string returned by mysqli connection functions.